### PR TITLE
feat: Multiprocess Logging and Shutdown Actors

### DIFF
--- a/bellboy/actors/__init__.py
+++ b/bellboy/actors/__init__.py
@@ -1,4 +1,0 @@
-import logging
-
-
-log = logging.getLogger("actors")

--- a/bellboy/actors/elevator.py
+++ b/bellboy/actors/elevator.py
@@ -4,11 +4,12 @@ class for the elevator and button related stuff.
 in actors for now.. could move
 """
 
-from actors import log
+import logging
+
 from collections import deque
 from utils.messages import SensorEvent, SensorEventMsg
 
-
+log = logging.getLogger("elevator")
 # simple "buttons", only have a position (depth) value and a radius.. all in cm
 BTN1_POS = 8.5
 BTN2_POS = 16

--- a/bellboy/actors/generic.py
+++ b/bellboy/actors/generic.py
@@ -1,6 +1,6 @@
+import logging
 from abc import ABC, abstractmethod
 
-from actors import log
 from thespian.actors import ActorAddress, ActorTypeDispatcher
 from utils.messages import Init, Response, StatusReq, SummaryReq, TestMode
 
@@ -67,11 +67,12 @@ class GenericActor(ActorTypeDispatcher, ABC):
         self._nameAddress(sender, message.senderName)
 
         if self.globalName is None:
-            log.warning("unnamed actor created!")
-            self.log = log.getChild(str(self.myAddress))
-        else:
-            self.log = log.getChild(self.globalName)
-            self.log.info(str.format("{} created by {}", self.globalName, sender))
+            self.globalName = str(self.myAddress)
+
+        self.log = logging.getLogger(self.globalName)
+        self.log.info(
+            str.format("{} created by {}", self.globalName, self.nameOf(sender))
+        )
 
         self.status = Response.READY
         self.send(sender, self.status)

--- a/bellboy/actors/generic.py
+++ b/bellboy/actors/generic.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from abc import ABC, abstractmethod
 
 from thespian.actors import ActorAddress, ActorTypeDispatcher
@@ -71,7 +72,12 @@ class GenericActor(ActorTypeDispatcher, ABC):
 
         self.log = logging.getLogger(self.globalName)
         self.log.info(
-            str.format("{} created by {}", self.globalName, self.nameOf(sender))
+            str.format(
+                "{} created by {}, pid={}",
+                self.globalName,
+                self.nameOf(sender),
+                os.getpid(),
+            )
         )
 
         self.status = Response.READY
@@ -86,24 +92,28 @@ class GenericActor(ActorTypeDispatcher, ABC):
         """Sends a status update to sender."""
         self.send(sender, self.status)
 
-    def receiveMsg_WakeupMessage(self, message: dict, sender: ActorAddress):
-        """On wakeup request."""
-        self.send(sender, Response.AWAKE)
-
-    @abstractmethod
     def receiveMsg_SummaryReq(self, message: SummaryReq, sender):
         """
-        sends a summary of the actor to the sender.
+        Sends a summary of the actor to the sender.
+        """
+        self.send(sender, self.summary())
 
-        to be defined in child classes.
+    def receiveMsg_ActorExitRequest(self, msg, sender):
+        """This is last msg processed before the Actor is shutdown."""
+        self.log.debug("Received shutdown message!")
+        self.teardown()
+
+    @abstractmethod
+    def teardown(self):
+        """
+        Actor's teardown sequence, called before shutdown. (i.e. close threads, disconnect from services, etc)
         """
         pass
 
-
-# NOTE:
-# If d actor isnt created by a bellboy actor, u must send an Init msg to it explicitly in order to use bellboy logs.
-# This should only matter for the lead actor and during testing,
-# cus all actors are sposed to be created thru bellboy lead anyways.
-# Reason is bc the actors are running in independent processes, they dont share globals, i.e. the logger.
-# Everything is communicated thru messaging.
-# tldr the init msg holds the addressbook and log configs together
+    @abstractmethod
+    def summary(self):
+        """
+        Returns a summary of the actor. The summary can be an object of any type described in the messages module.
+        :rtype: object
+        """
+        pass

--- a/bellboy/actors/lead.py
+++ b/bellboy/actors/lead.py
@@ -16,8 +16,7 @@ class BellboyLeadActor(GenericActor):
         """
         Starts bellboy lead actor services.
 
-        Configures global RPI Board. Spawns and sets up child actors
-        (ultrasonic sensor).
+        Spawns and sets up child actors
         """
         self.log.info("Starting bellboy services.")
 
@@ -54,14 +53,6 @@ class BellboyLeadActor(GenericActor):
 
         elif message is Request.STOP:
             self.stopBellboyLead()
-
-        elif message is Request.STATUS:
-            self.log.debug(str.format("Status check - {}", Response.ALIVE.name))
-
-        else:
-            msg = "Unhandled Request Enum value sent."
-            self.log.error(msg)
-            raise Exception(msg)
 
         self.send(sender, self.status)
 

--- a/bellboy/actors/lead.py
+++ b/bellboy/actors/lead.py
@@ -92,7 +92,10 @@ class BellboyLeadActor(GenericActor):
             self.log.debug("received 3 events, turning off sensor.")
             self.send(self.ultrasonic_sensor, SensorReq.STOP)
 
-    def receiveMsg_SummaryReq(self, message, sender):
-        """sends a summary of the actor."""
+    def summary(self):
+        """Returns a summary of the actor."""
+        return self.status
         # TODO flesh this out...
-        self.send(sender, self.status)
+
+    def teardown(self):
+        pass

--- a/bellboy/actors/ultrasonic.py
+++ b/bellboy/actors/ultrasonic.py
@@ -83,20 +83,20 @@ class UltrasonicActor(GenericActor):
         """
         self.status = SensorResp.POLLING
         self._buffer.clear()
-
+        self.log.info("starting sensor loop")
         while not self._terminate_thread:
+
             t0 = time.time()
-            self._buffer.appendleft(self._sensor.distance * 100.0)
+            if not self.TEST_MODE:
+                self._buffer.appendleft(self._sensor.distance * 100.0)
 
-            # check for event, if occurred send msg to subscriber
-            event = self._eventFunc(self._buffer)
-            if event:
-                self.send(self.parent, event)
+                # check for event, if occurred send msg to subscriber
+                event = self._eventFunc(self._buffer)
+                if event:
+                    self.send(self.parent, event)
 
-            # sleep till next period
+            # sleep till next period, o next mltiple of period
             dt_msec = (time.time() - t0) * MS_PER_SEC
-            # wait till next period if time took too long.
-
             if dt_msec > self._poll_period:
                 self.log.warning(
                     str.format(
@@ -114,7 +114,6 @@ class UltrasonicActor(GenericActor):
         """Begins running the polling thread."""
         self._terminate_thread = False
         self._sensor_thread = Thread(target=self._sensor_loop)
-        self.log.info("starting sensor's thread")
         self._sensor_thread.start()
         self.status = SensorResp.POLLING
 
@@ -125,7 +124,6 @@ class UltrasonicActor(GenericActor):
 
         self.log.debug("Stopping the UltraSonic detection loop...")
         self._terminate_thread = True
-        self.status = SensorResp.SET
 
     def _clear(self):
         self._trigPin = 0
@@ -203,14 +201,19 @@ class UltrasonicActor(GenericActor):
 
         self.send(sender, self.status)
 
-    def receiveMsg_SummaryReq(self, message, sender):
+    # ----------#
+    # OVERRIDES #
+    # ----------#
+
+    def teardown(self):
+        """ Sensor teardown, ensures polling thread is dead"""
+        self._stop_polling()
+
+    def summary(self):
         """sends a summary of the actor."""
-        self.send(
-            sender,
-            SensorMsg(
-                type=Response.SUMMARY,
-                trigPin=self._trigPin,
-                echoPin=self._echoPin,
-                maxDepth_cm=self._max_depth_cm,
-            ),
+        return SensorMsg(
+            type=Response.SUMMARY,
+            trigPin=self._trigPin,
+            echoPin=self._echoPin,
+            maxDepth_cm=self._max_depth_cm,
         )

--- a/bellboy/actors/ultrasonic.py
+++ b/bellboy/actors/ultrasonic.py
@@ -57,7 +57,7 @@ class UltrasonicActor(GenericActor):
 
         if not self.TEST_MODE:
             try:
-                import RPi # noqa
+                import RPi  # noqa
             except ImportError:
                 self.log.warning("Not on RPI - Offtarget mode on")
                 self.TEST_MODE = True

--- a/bellboy/actors/ultrasonic.py
+++ b/bellboy/actors/ultrasonic.py
@@ -55,6 +55,13 @@ class UltrasonicActor(GenericActor):
         self._echoPin = echoPin
         self._max_depth_cm = max_depth_cm
 
+        if not self.TEST_MODE:
+            try:
+                import RPi
+            except ImportError:
+                self.log.warning("Not on RPI - Offtarget mode on")
+                self.TEST_MODE = True
+
         if self.TEST_MODE:
             gpiozero.Device.pin_factory = MockFactory()
             # TODO should this be "globally" set in the test suites...

--- a/bellboy/actors/ultrasonic.py
+++ b/bellboy/actors/ultrasonic.py
@@ -57,7 +57,7 @@ class UltrasonicActor(GenericActor):
 
         if not self.TEST_MODE:
             try:
-                import RPi
+                import RPi # noqa
             except ImportError:
                 self.log.warning("Not on RPI - Offtarget mode on")
                 self.TEST_MODE = True

--- a/bellboy/main.py
+++ b/bellboy/main.py
@@ -4,21 +4,23 @@ from time import sleep
 from actors.lead import BellboyLeadActor
 from thespian.actors import ActorSystem
 from utils.cli import get_bellboy_configs
-from utils.messages import Init, Request, Response
+from utils.messages import Init, Request, Response, StatusReq
 
 
 def main():
     """Starts the Bellboy system by  creating an ActorSystem, creating the
     LeadActor, and asking it to START."""
 
-    logcfgs = get_bellboy_configs()
+    configs = get_bellboy_configs()
 
-    # for logging in main
+    # Initialize the Actor system
+    system = ActorSystem(systemBase="multiprocQueueBase", logDefs=configs["logcfg"])
+
+    # for logging here in main
     log = logging.getLogger("Main")
     log.info("Starting the Bellboy system")
 
-    # Initialize the Actor system
-    system = ActorSystem(systemBase="multiprocQueueBase", logDefs=logcfgs)
+    # lead actor
     bellboy = system.createActor(BellboyLeadActor, globalName="bellboy_lead")
     status = system.ask(bellboy, Init())
 
@@ -33,7 +35,7 @@ def main():
         while True:
             sleep(10)
             log.debug("Sending Heartbeat request to lead actor.")
-            system.tell(bellboy, Request.STATUS)
+            system.ask(bellboy, StatusReq())
 
     except KeyboardInterrupt:
         log.error("The bellboy system was interrupted by the keyboard, exiting...")

--- a/bellboy/main.py
+++ b/bellboy/main.py
@@ -3,7 +3,7 @@ from time import sleep
 
 from actors.lead import BellboyLeadActor
 from thespian.actors import ActorSystem
-from utils.cli import configure_bellboy
+from utils.cli import get_bellboy_configs
 from utils.messages import Init, Request, Response
 
 
@@ -11,13 +11,14 @@ def main():
     """Starts the Bellboy system by  creating an ActorSystem, creating the
     LeadActor, and asking it to START."""
 
-    configure_bellboy()
+    logcfgs = get_bellboy_configs()
 
-    log = logging.getLogger("Bellboy")
+    # for logging in main
+    log = logging.getLogger("Main")
     log.info("Starting the Bellboy system")
 
     # Initialize the Actor system
-    system = ActorSystem(systemBase="multiprocQueueBase")
+    system = ActorSystem(systemBase="multiprocQueueBase", logDefs=logcfgs)
     bellboy = system.createActor(BellboyLeadActor, globalName="bellboy_lead")
     status = system.ask(bellboy, Init())
 

--- a/bellboy/main.py
+++ b/bellboy/main.py
@@ -40,7 +40,7 @@ def main():
     except KeyboardInterrupt:
         log.error("The bellboy system was interrupted by the keyboard, exiting...")
     finally:
-        system.tell(bellboy, Request.STOP)
+        system.shutdown()
 
 
 if __name__ == "__main__":

--- a/bellboy/tests/__init__.py
+++ b/bellboy/tests/__init__.py
@@ -1,0 +1,35 @@
+import pytest
+from thespian.actors import ActorSystem as ThespianActorSystem
+
+
+@pytest.mark.skip(reason="actorsystem context manager, not a testing class")
+class ActorSystem(object):
+    def __init__(self, systemBase: str, logcfg: dict):
+        self.test_system = ThespianActorSystem(
+            systemBase="multiprocQueueBase", logDefs=logcfg
+        )
+
+    def __enter__(self):
+        return self.test_system
+
+    def __exit__(self, type, value, traceback):
+        self.test_system.shutdown()
+
+
+logcfg = {
+    "version": 1,
+    "formatters": {
+        "standard": {
+            "format": "%(asctime)s :: %(levelname)s :: %(name)s :: %(funcName)s() :: %(message)s"
+        },
+    },
+    "handlers": {
+        "sh": {
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+            "formatter": "standard",
+            "level": "INFO",
+        },
+    },
+    "loggers": {"": {"handlers": ["sh"], "level": "INFO"}},
+}

--- a/bellboy/tests/actors/test_lead.py
+++ b/bellboy/tests/actors/test_lead.py
@@ -1,12 +1,13 @@
 import time
 
 from actors.lead import BellboyLeadActor
-from thespian.actors import ActorSystem
+from tests import ActorSystem, logcfg
 from utils.messages import Init, Request, Response, TestMode
 
 
-class TestLeadActor:
-    def test_receiveMsg_Requests(self, actor_system: ActorSystem):
+def test_leadActor():
+
+    with ActorSystem("multiprocQueueBase", logcfg) as actor_system:
         lead = actor_system.createActor(BellboyLeadActor, globalName="test_lead")
         status = actor_system.ask(lead, Init(senderName="test_system"))
         assert status == Response.READY

--- a/bellboy/tests/actors/test_ultrasonic.py
+++ b/bellboy/tests/actors/test_ultrasonic.py
@@ -1,6 +1,8 @@
 from actors.elevator import buttonHovered
 from actors.ultrasonic import UltrasonicActor
-from thespian.actors import ActorSystem
+
+import time
+from tests import ActorSystem, logcfg
 from utils.messages import (
     Init,
     Response,
@@ -13,10 +15,7 @@ from utils.messages import (
 )
 
 
-test_system = ActorSystem(systemBase="multiprocQueueBase")
-
-
-def check_ultrasonicActor_setup(ultrasonic_actor):
+def check_ultrasonicActor_setup(ultrasonic_actor, test_system):
     # ensure the ultrasonic sensor only accepts setup reqs from its parent
     test_trigPin = 10
     test_echoPin = 11
@@ -47,9 +46,11 @@ def check_ultrasonicActor_setup(ultrasonic_actor):
     assert status == Response.READY
 
 
-def check_ultrasonicActor_poll(ultrasonic_actor):
+def check_ultrasonicActor_poll(ultrasonic_actor, test_system):
+
+    pollperiod_ms = 100.0
     poll_req = SensorMsg(
-        type=SensorReq.POLL, triggerFunc=buttonHovered, pollPeriod_ms=100.0
+        type=SensorReq.POLL, triggerFunc=buttonHovered, pollPeriod_ms=pollperiod_ms
     )
     setup_req = SensorMsg(
         type=SensorReq.SETUP, trigPin=10, echoPin=11, maxDepth_cm=100.0
@@ -73,8 +74,13 @@ def check_ultrasonicActor_poll(ultrasonic_actor):
     status = test_system.ask(ultrasonic_actor, StatusReq())
     assert status == SensorResp.POLLING
 
+    time.sleep(3 * pollperiod_ms / 1000.0)
+
     # stop polling
     status = test_system.tell(ultrasonic_actor, SensorReq.STOP)
+
+    time.sleep(pollperiod_ms / 1000.0)
+
     status = test_system.ask(ultrasonic_actor, StatusReq())
     assert status == SensorResp.SET
 
@@ -86,16 +92,17 @@ def check_ultrasonicActor_poll(ultrasonic_actor):
 # main test
 def test_ultrasonicActor():
 
-    # create actor, ensure its ready to recieve messages
-    ultrasonic_actor = test_system.createActor(
-        UltrasonicActor, globalName="test_ultrasonic"
-    )
-    ultrasonic_status = test_system.ask(
-        ultrasonic_actor, Init(senderName="test_system")
-    )
-    assert ultrasonic_status == Response.READY
-    test_system.tell(ultrasonic_actor, TestMode())
+    with ActorSystem("multiprocQueueBase", logcfg) as test_system:
+        # create actor, ensure its ready to recieve messages
+        ultrasonic_actor = test_system.createActor(
+            UltrasonicActor, globalName="test_ultrasonic"
+        )
+        ultrasonic_status = test_system.ask(
+            ultrasonic_actor, Init(senderName="test_system")
+        )
+        assert ultrasonic_status == Response.READY
+        test_system.tell(ultrasonic_actor, TestMode())
 
-    # test behaviours
-    check_ultrasonicActor_setup(ultrasonic_actor)
-    check_ultrasonicActor_poll(ultrasonic_actor)
+        # test behaviours
+        check_ultrasonicActor_setup(ultrasonic_actor, test_system)
+        check_ultrasonicActor_poll(ultrasonic_actor, test_system)

--- a/bellboy/utils/cli.py
+++ b/bellboy/utils/cli.py
@@ -1,7 +1,5 @@
 """
-Setup of Bellboy run configurations, i.e. logging and run level.
-
-All command line processing here.
+Bellboy command line argument processing goes here.
 """
 
 import logging
@@ -9,45 +7,12 @@ import os
 from argparse import ArgumentParser
 
 
-def configure_logging(log_level):
+def get_bellboy_configs():
+    """Retrieve bellboy configuration information from command line arguments.
+
+    :return: configs
+    :rtype: dict
     """
-    configures logging globally through root logger.
-
-    :param log_level: log verbosity
-    :type log_level: logging.LEVEL
-    """
-    log_filename = "bellboy_log.txt"
-    root_logger = logging.getLogger()
-    root_logger.setLevel(log_level)
-
-    # create file logging handler & console logging handler
-    fh = logging.FileHandler(log_filename)
-    fh.setLevel(log_level)
-    ch = logging.StreamHandler()
-    ch.setLevel(log_level)
-
-    # create formatter and add it to the handlers
-    formatter = logging.Formatter(
-        "%(asctime)s :: %(levelname)s :: %(name)s :: %(funcName)s() :: %(message)s"
-    )
-    fh.setFormatter(formatter)
-    ch.setFormatter(formatter)
-
-    # add the handlers to the logger
-    root_logger.addHandler(fh)
-    root_logger.addHandler(ch)
-    root_logger.info(
-        "Logging configured to console and {} at {} level".format(
-            os.path.abspath(log_filename),
-            logging.getLevelName(root_logger.getEffectiveLevel()),
-        )
-    )
-
-
-# parse arguments
-
-
-def configure_bellboy():
     # command line argument parsing
     parser = ArgumentParser(
         prog="python<x> main.py",
@@ -81,8 +46,33 @@ def configure_bellboy():
     )
     args = parser.parse_args()
 
-    # configure system to chosen settings.
-    configure_logging(args.log_level)
     logging.getLogger().info(
         f"Running at log level {args.log_level} and run level {args.run_level}"
     )
+
+    # using log config dictionary, check thespian docs for more
+    logcfg = {
+        "version": 1,
+        "formatters": {
+            "standard": {
+                "format": "%(asctime)s :: %(levelname)s :: %(name)s :: %(funcName)s() :: %(message)s"
+            },
+        },
+        "handlers": {
+            "fh": {
+                "class": "logging.FileHandler",
+                "filename": "bellboy.log",
+                "formatter": "standard",
+                "level": args.log_level,
+            },
+            "sh": {
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+                "formatter": "standard",
+                "level": args.log_level,
+            },
+        },
+        "loggers": {"": {"handlers": ["fh", "sh"], "level": logging.DEBUG}},
+    }
+
+    return logcfg

--- a/bellboy/utils/cli.py
+++ b/bellboy/utils/cli.py
@@ -3,6 +3,7 @@ Bellboy command line argument processing goes here.
 """
 
 import logging
+import logging.config
 import os
 from argparse import ArgumentParser
 
@@ -48,16 +49,9 @@ def get_bellboy_configs():
     )
     args = parser.parse_args()
 
-    logging.getLogger().info(
-        str.format(
-            "Logging configured to console and {} at {} level",
-            os.path.abspath(log_filename),
-            logging.getLevelName(args.log_level),
-        )
-    )
-
-    # using log config dictionary, check thespian docs for more
-    logcfg = {
+    # using log config dictionary for actor logging, check thespian docs for more
+    configs = {}
+    configs["logcfg"] = {
         "version": 1,
         "formatters": {
             "standard": {
@@ -81,4 +75,15 @@ def get_bellboy_configs():
         "loggers": {"": {"handlers": ["fh", "sh"], "level": logging.DEBUG}},
     }
 
-    return logcfg
+    configs["run_level"] = args.run_level
+    configs["log_level"] = args.log_level
+    logging.config.dictConfig(configs["logcfg"])
+    logging.getLogger().info(
+        str.format(
+            "Logging configured to console and {} at {} level",
+            os.path.abspath(log_filename),
+            logging.getLevelName(logging.getLevelName(args.log_level)),
+        )
+    )
+
+    return configs

--- a/bellboy/utils/cli.py
+++ b/bellboy/utils/cli.py
@@ -6,6 +6,8 @@ import logging
 import os
 from argparse import ArgumentParser
 
+log_filename = "bellboy.log"
+
 
 def get_bellboy_configs():
     """Retrieve bellboy configuration information from command line arguments.
@@ -47,7 +49,11 @@ def get_bellboy_configs():
     args = parser.parse_args()
 
     logging.getLogger().info(
-        f"Running at log level {args.log_level} and run level {args.run_level}"
+        str.format(
+            "Logging configured to console and {} at {} level",
+            os.path.abspath(log_filename),
+            logging.getLevelName(args.log_level),
+        )
     )
 
     # using log config dictionary, check thespian docs for more
@@ -61,7 +67,7 @@ def get_bellboy_configs():
         "handlers": {
             "fh": {
                 "class": "logging.FileHandler",
-                "filename": "bellboy.log",
+                "filename": log_filename,
                 "formatter": "standard",
                 "level": args.log_level,
             },

--- a/bellboy/utils/messages.py
+++ b/bellboy/utils/messages.py
@@ -27,7 +27,7 @@ class TestMode:
 
 # general requests
 class Request(Enum):
-    START, STOP, STATUS, CLEAR = range(4)
+    START, STOP, CLEAR = range(3)
 
 
 # general responses


### PR DESCRIPTION
Logging through Thespian constraints. 
+ proper actor shutdown
Using shutdown() to cleanly shutdown the multiprocess actors.
Introduced teardown to generic actor, so any teardown sequence can be overriden if need be
multiprocess logging fix included. logging config defined by dict in cli.